### PR TITLE
Fix type hints

### DIFF
--- a/src/mappers.py
+++ b/src/mappers.py
@@ -13,7 +13,8 @@ __all__ = ('prepare_events', 'group_orders_by_unit_name')
 
 logger = structlog.stdlib.get_logger('app')
 
-OrdersGroupedByUnitName: TypeAlias = itertools.groupby[str, DetailedOrder]
+DetailedOrders: TypeAlias = Iterable[DetailedOrder]
+OrdersGroupedByUnitName: TypeAlias = Iterable[tuple[str, DetailedOrders]]
 
 
 def group_orders_by_unit_name(


### PR DESCRIPTION
It turned out that itertools.groupby object does not support type hints. 
So we'll be using generic types for type hints.